### PR TITLE
[CMPT-2508] [node-cleanup] Fix in aws

### DIFF
--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -480,7 +480,9 @@ func TestGetVolumeMode(t *testing.T) {
 func TestNodeExists(t *testing.T) {
 	node := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-node",
+			Labels: map[string]string{
+				NodeLabelKey: "test-node",
+			},
 		},
 	}
 
@@ -510,7 +512,7 @@ func TestNodeExists(t *testing.T) {
 			nodeInformer.Informer().GetStore().Add(test.nodeAdded)
 		}
 
-		exists, err := NodeExists(nodeInformer.Lister(), test.nodeQueried.Name)
+		exists, err := NodeExists(nodeInformer.Lister(), test.nodeQueried.Labels[NodeLabelKey])
 		if err != nil {
 			t.Errorf("Got unexpected error: %s", err.Error())
 		}

--- a/pkg/node-cleanup/controller/controller_test.go
+++ b/pkg/node-cleanup/controller/controller_test.go
@@ -330,7 +330,7 @@ func pvWithPVCAndNode(pvc *v1.PersistentVolumeClaim, node *v1.Node) *v1.Persiste
 						{
 							Key:      common.NodeLabelKey,
 							Operator: v1.NodeSelectorOpIn,
-							Values:   []string{node.Name},
+							Values:   []string{node.Labels[common.NodeLabelKey]},
 						},
 					},
 				},
@@ -351,7 +351,7 @@ func pvWithNode(node *v1.Node) *v1.PersistentVolume {
 						{
 							Key:      common.NodeLabelKey,
 							Operator: v1.NodeSelectorOpIn,
-							Values:   []string{node.Name},
+							Values:   []string{node.Labels[common.NodeLabelKey]},
 						},
 					},
 				},
@@ -386,7 +386,7 @@ func pvcWithUID(uid string) *v1.PersistentVolumeClaim {
 func node() *v1.Node {
 	return &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: defaultNodeName,
+			Labels: map[string]string{common.NodeLabelKey: defaultNodeName},
 		},
 	}
 }

--- a/pkg/node-cleanup/deleter/deleter_test.go
+++ b/pkg/node-cleanup/deleter/deleter_test.go
@@ -211,7 +211,7 @@ func localPV(node *v1.Node, phase v1.PersistentVolumePhase, reclaimPolicy v1.Per
 								{
 									Key:      common.NodeLabelKey,
 									Operator: v1.NodeSelectorOpIn,
-									Values:   []string{node.Name},
+									Values:   []string{node.Labels[common.NodeLabelKey]},
 								},
 							},
 						},
@@ -230,7 +230,7 @@ func localPV(node *v1.Node, phase v1.PersistentVolumePhase, reclaimPolicy v1.Per
 func node() *v1.Node {
 	return &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: testNodeName,
+			Labels: map[string]string{common.NodeLabelKey: testNodeName},
 		},
 	}
 }


### PR DESCRIPTION
In our aws clusters, the node name is not the same as the `kuberenetes.io/hostname` label (`ip-10-128-187-24.ec2.internal` vs `ip-10-128-187-24`). As a result, PV and PVC are getting deleted while their node still exists. 
This PR changes how we check if the PV is bound to an existing node to use the label when getting the node instead of the node.name.