### PR TITLE
[local] Bump golang in test and use gotoolchain

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,9 @@ include: https://gitlab-templates.ddbuild.io/compute-delivery/v2/compute-deliver
 test:
   stage: verify
   tags: [ "arch:amd64" ]
-  image: registry.ddbuild.io/images/mirror/golang:1.21
+  image: registry.ddbuild.io/images/mirror/golang:1.23.5
+  variables:
+    GOTOOLCHAIN: "auto"
   script:
     - go test ./cmd/... ./pkg/... -v
 


### PR DESCRIPTION
Tests are failing in CI because of this